### PR TITLE
feat: adding mdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,38 @@ import readingTime from "remark-reading-time";
 remark()
   .use(readingTime())
   .process(markdown, function (err, file) {
-    console.log("Reading time is " + file.data.fm.readingTime.text);
+    console.log("Reading time is " + file.data.readingTime.text);
   });
 ```
 
-By default, it will add the data to `readingTime` in your frontmatter. This can be changed:
+By default, it will add the data to `readingTime` in your data. This can be
+changed:
 
 ```js
 import readingTime from "remark-reading-time";
 
 remark()
-  .use(readingTime({ attribute: "length" }))
+  .use(readingTime({ attribute: "myKeyName" }))
   .process(markdown, function (err, file) {
-    console.log("Reading time is " + file.data.fm.length.text);
+    console.log("Reading time is " + file.data.myKeyName.text);
   });
+```
+
+### MDX
+
+You can also export the data to MDX files:
+
+```js
+import {compile} from '@mdx-js/mdx'
+import readingTime from "remark-reading-time";
+import readingMdxTime from "remark-reading-time/mdx";
+
+const code = await compile(file, {
+  compileOptions: {
+    remarkPlugins: [
+      remarkReadingTime,
+      readingMdxTime, // register the mdx after the remarkReadingTime plugin
+    ],
+  }
+});
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import type { Plugin } from 'unified'
+
+declare const remarkReadingTime: Plugin<[{ name?: string }]>
+
+export default remarkReadingTime

--- a/index.js
+++ b/index.js
@@ -3,27 +3,20 @@ import { visit } from "unist-util-visit";
 
 export default function readingTime({
   /**
-   * The attribute name to store the reading time under in frontmatter
+   * The attribute name to store the reading time under data.
    *
    * @type {string}
    * @default "readingTime"
    */
   attribute = "readingTime",
 } = {}) {
-  return () => {
-    return function (info, file) {
-      let text = "";
+  return function (info, file) {
+    let text = "";
 
-      visit(info, ["text", "code"], (node) => {
-        text += node.value;
-      });
+    visit(info, ["text", "code"], (node) => {
+      text += node.value;
+    });
 
-      const time = getReadingTime(text);
-
-      file.data.fm = {
-        ...file.data.fm,
-        [attribute]: time,
-      };
-    };
+    file.data[attribute] = getReadingTime(text);
   };
 }

--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -1,0 +1,5 @@
+import type { Plugin } from 'unified'
+
+declare const remarkMdxReadingTime: Plugin<[{ name?: string; remarkReadingTimeName?: string }]>
+
+export default remarkMdxReadingTime

--- a/mdx.js
+++ b/mdx.js
@@ -1,0 +1,61 @@
+import { name as isIdentifierName } from 'estree-util-is-identifier-name'
+import { valueToEstree } from 'estree-util-value-to-estree'
+
+export default function remarkMdxReadingTime({
+  /**
+   * The attribute name to export the stored the reading time under data.
+   *
+   * @type {string}
+   * @default "readingTime"
+   */
+  name = 'readingTime',
+  /**
+   * The attribute name to store the reading time under data in remark plugin.
+   *
+   * @type {string}
+   * @default "readingTime"
+   */
+  remarkReadingTimeName = 'readingTime'
+} = {}) {
+  if (!isIdentifierName(name)) {
+    throw new Error(
+      `The name should be a valid identifier name, got: ${JSON.stringify(
+        name,
+      )}`,
+    )
+  }
+
+  return function transformer(tree, vfile) {
+    const readingTime = vfile.data[remarkReadingTimeName];
+
+    if (readingTime === undefined) return
+
+    tree.children.unshift({
+      type: 'mdxjsEsm',
+      data: {
+        estree: {
+          type: 'Program',
+          sourceType: 'module',
+          body: [
+            {
+              type: 'ExportNamedDeclaration',
+              source: null,
+              specifiers: [],
+              declaration: {
+                type: 'VariableDeclaration',
+                kind: 'const',
+                declarations: [
+                  {
+                    type: 'VariableDeclarator',
+                    id: { type: 'Identifier', name },
+                    init: valueToEstree(readingTime),
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-reading-time",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Adds estimated reading time to your markdown files",
   "main": "index.js",
   "type": "module",
@@ -14,6 +14,8 @@
     "remark": "^13.0.0"
   },
   "dependencies": {
+    "estree-util-is-identifier-name": "^2.0.0",
+    "estree-util-value-to-estree": "^1.3.0",
     "reading-time": "^1.3.0",
     "unist-util-visit": "^3.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11 +1,15 @@
 lockfileVersion: 5.3
 
 specifiers:
+  estree-util-is-identifier-name: ^2.0.0
+  estree-util-value-to-estree: ^1.3.0
   reading-time: ^1.3.0
   remark: ^13.0.0
   unist-util-visit: ^3.1.0
 
 dependencies:
+  estree-util-is-identifier-name: registry.npmjs.org/estree-util-is-identifier-name/2.0.0
+  estree-util-value-to-estree: registry.npmjs.org/estree-util-value-to-estree/1.3.0
   reading-time: 1.3.0
   unist-util-visit: 3.1.0
 
@@ -231,3 +235,25 @@ packages:
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
+
+  registry.npmjs.org/estree-util-is-identifier-name/2.0.0:
+    resolution: {integrity: sha512-aXXZFVMnBBDRP81vS4YtAYJ0hUkgEsXea7lNKWCOeaAquGb1Jm2rcONPB5fpzwgbNxulTvrWuKnp9UElUGAKeQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-2.0.0.tgz}
+    name: estree-util-is-identifier-name
+    version: 2.0.0
+    dev: false
+
+  registry.npmjs.org/estree-util-value-to-estree/1.3.0:
+    resolution: {integrity: sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz}
+    name: estree-util-value-to-estree
+    version: 1.3.0
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      is-plain-obj: registry.npmjs.org/is-plain-obj/3.0.0
+    dev: false
+
+  registry.npmjs.org/is-plain-obj/3.0.0:
+    resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz}
+    name: is-plain-obj
+    version: 3.0.0
+    engines: {node: '>=10'}
+    dev: false

--- a/test.js
+++ b/test.js
@@ -8,5 +8,5 @@ remark()
     if (err) {
       console.error(err);
     }
-    console.log(file.data.fm);
+    console.log(file.data.readingTime);
   });


### PR DESCRIPTION
## Breaking Changes

### Initializing the plugin

Followed the convention of returning the `Plugin` from the function instead of another closure.

Before:

```ts
remarkPlugins: [
  // the conventional config is ignored, this doesn't work
  [remarkReadingTime(), { name: 'ignoredConfig' }],
],
```


After:

```ts
remarkPlugins: [
  [remarkReadingTime, { name: 'myKeyName' }],
],
```

### Storing the data

Previously, you use `vfile.data.fm` and under `vfile.data.fm` you could configure the key name for the reading time.

Normally, the data should be store under `vfile.data.[myPluginNameKeyConfig]` to avoid breaking other plugins that may use `fm` directly as their key.

## New Features

Adds support for `mdx` exporting.